### PR TITLE
[volume-6] 포인트 조회 및 테스트 작성

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -18,4 +18,8 @@ public class PointFacade {
         return PointInfo.from(model);
     }
 
+    public PointInfo getMyPoint(String userId) {
+        PointModel model = pointService.getMyPoint(userId);
+        return PointInfo.from(model);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -40,4 +40,15 @@ public class PointService {
         return pointRepository.create(point);
     }
 
+    public PointModel getMyPoint(String userId) {
+        if (!userRepository.existsByUserId(new UserId(userId))) {
+            return null;
+        }
+        return pointRepository.findByUserId(new UserId(userId))
+                .orElseGet(() -> pointRepository.create(PointModel.builder()
+                        .userId(new UserId(userId))
+                        .amount(0)
+                        .build()
+                ));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiResponse.java
@@ -1,6 +1,10 @@
 package com.loopers.interfaces.api;
 
+import org.springframework.http.HttpStatus;
+
 public record ApiResponse<T>(Metadata meta, T data) {
+
+
     public record Metadata(Result result, String errorCode, String message) {
         public enum Result {
             SUCCESS, FAIL
@@ -28,5 +32,9 @@ public record ApiResponse<T>(Metadata meta, T data) {
             Metadata.fail(errorCode, errorMessage),
             null
         );
+    }
+
+    public static ApiResponse<Object> error(HttpStatus httpStatus, String message) {
+        return new ApiResponse<>(Metadata.fail(httpStatus.name(), message),null );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -14,4 +14,7 @@ public interface PointV1ApiSpec {
     @Operation(summary = "포인트 충전", description = "포인트를 충전합니다.")
     ApiResponse<PointV1Dto.PointResponse> chargePoint(@RequestHeader("X-USER-ID") String userId, @RequestBody PointV1Dto.PointRequest request);
 
+    @Operation(summary = "포인트 조회", description = "사용자의 포인트 정보를 조회합니다.")
+    ApiResponse<Object> getPoint(@RequestHeader("X-USER-ID") String userId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,9 +1,8 @@
 package com.loopers.interfaces.api.point;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.web.bind.annotation.*;
 
 import com.loopers.application.point.PointFacade;
 import com.loopers.application.point.PointInfo;
@@ -11,7 +10,6 @@ import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.point.PointV1Dto.PointRequest;
 import com.loopers.interfaces.api.point.PointV1Dto.PointResponse;
 
-import org.springframework.web.bind.annotation.RequestBody;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -29,6 +27,18 @@ public class PointV1Controller implements PointV1ApiSpec{
     ) {
         PointInfo info = pointFacade.chargeMyPoint(userId, request.amount());
 
+        PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping
+    @Override
+    public ApiResponse<Object> getPoint(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 헤더가 필요합니다.");
+        }
+        PointInfo info = pointFacade.getMyPoint(userId);
         PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(info);
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -70,5 +70,45 @@ public class PointServiceIntegrationTest {
         }
     }
 
+    @DisplayName("포인트 조회 테스트")
+    @Nested
+    class GetPoint {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void getMyPointSuccess() {
+            // given
+            UserModel user = userRepository.create(UserModel.builder()
+                    .userId(new UserId("seyoung"))
+                    .email(new Email("seyoung@loopers.com"))
+                    .gender(Gender.MALE)
+                    .birthDate(new BirthDate("2000-01-01"))
+                    .build());
+            int initialAmount = 500;
+            pointService.chargeMyPoint(user.getUserId().getValue(), initialAmount);
+
+            // when
+            PointModel pointModel = pointService.getMyPoint(user.getUserId().getValue());
+
+            // then
+            assertThat(pointModel.getUserId()).isEqualTo(user.getUserId());
+            assertThat(pointModel.getAmount()).isEqualTo(initialAmount);
+
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void getMyPointFailureInvalidUserId() {
+            // given
+            String userId = "seyoung123";
+
+            // when
+            PointModel pointModel = pointService.getMyPoint(userId);
+
+            // then
+            assertThat(pointModel).isNull();
+        }
+    }
+
 
 }


### PR DESCRIPTION
## 📌 Summary
헤더로 받은 유저 정보로 포인트 조회
통합테스트

## 💬 Review Points
- 현재 헤더가 존재하지 않는 경우 400 Bad Request로 반환하기 위해 컨트롤러에서 CoreException을 사용하고 있는데 몹시 불편하게 느껴집니다... 헤더값을 required = true 로 두면 500 에러로 떨어져서 이같은 방법을 사용하였는데 더 깔끔한 방법이 있다면 조언 구하고 싶습니다.

## ✅ Checklist
- [x] 포인트 조회 E2E 테스트 작성
- [x] 포인트 interface 작성
- [x] 통합테스트 및 도메인 서비스 완성
